### PR TITLE
Introduce a splash activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,13 +11,14 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
-        <activity android:name=".login.LoginActivity">
+        <activity android:name=".splash.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".login.LoginActivity" />
         <activity
             android:name=".chat.ChatActivity"
             android:label="@string/app_name">

--- a/app/src/main/java/com/tristanwiley/chatse/App.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/App.kt
@@ -1,59 +1,22 @@
 package com.tristanwiley.chatse
 
 import android.app.Application
-import android.content.SharedPreferences
-import android.preference.PreferenceManager
 import com.crashlytics.android.Crashlytics
 import io.fabric.sdk.android.Fabric
 
-/**
- * Application class that manages certain constants for us.
- */
 class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
         Fabric.with(this, Crashlytics())
-        com.tristanwiley.chatse.App.Companion.instance = this
+        instance = this
     }
 
     companion object {
-
         /**
-         * Key for storing the user's email in shared preferences.
+         * The application instance.
          */
-        val PREF_EMAIL = "email"
-
-        /**
-         * Key for storing the user's credentials in shared preferences.
-         */
-        val PREF_HAS_CREDS = "creds"
-
-        /**
-         * Key for passing the room number as an intent extra.
-         */
-        val EXTRA_ROOM_NUM = "room"
-
-        /**
-         * Key for passing the site name as an intent extra.
-         */
-        val EXTRA_SITE = "site"
-
-        /**
-         * Key for passing the fkey as an intent extra.
-         */
-        val EXTRA_FKEY = "fkey"
-
-        /**
-         * The application context.
-         */
-        lateinit var instance: com.tristanwiley.chatse.App
+        lateinit var instance: App
             private set
-
-        /**
-         * The default SharedPreferences for this application.
-         */
-        val sharedPreferences: SharedPreferences
-            get() = PreferenceManager.getDefaultSharedPreferences(com.tristanwiley.chatse.App.Companion.instance)
     }
 }

--- a/app/src/main/java/com/tristanwiley/chatse/login/LoginActivity.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/login/LoginActivity.kt
@@ -13,12 +13,13 @@ import android.widget.TextView
 import android.widget.Toast
 import com.squareup.okhttp.FormEncodingBuilder
 import com.squareup.okhttp.Request
-import com.tristanwiley.chatse.App
 import com.tristanwiley.chatse.BuildConfig
 import com.tristanwiley.chatse.R
 import com.tristanwiley.chatse.chat.ChatActivity
 import com.tristanwiley.chatse.network.Client
 import com.tristanwiley.chatse.network.ClientManager
+import com.tristanwiley.chatse.util.SharedPreferenceManager
+import com.tristanwiley.chatse.util.UserPreferenceKeys
 import kotlinx.android.synthetic.main.activity_login_beautiful.*
 import org.jetbrains.anko.defaultSharedPreferences
 import org.jetbrains.anko.doAsync
@@ -37,7 +38,7 @@ import java.util.*
  * @property prefs: Variable used to contain the default SharedPreferences for the app. Set to App.sharedPreferences
  */
 class LoginActivity : AppCompatActivity() {
-    private val prefs = App.sharedPreferences
+    private val prefs = SharedPreferenceManager.sharedPreferences
     lateinit var betaText: TextView
     lateinit var emailView: EditText
     lateinit var passwordView: EditText
@@ -49,7 +50,7 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login_beautiful)
 
-        activity_login_tv_version.text = String.format(Locale.getDefault(),getString(R.string.app_version), BuildConfig.VERSION_NAME)
+        activity_login_tv_version.text = String.format(Locale.getDefault(), getString(R.string.app_version), BuildConfig.VERSION_NAME)
 
         dialog = ProgressDialog(this)
         dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER)
@@ -72,7 +73,7 @@ class LoginActivity : AppCompatActivity() {
         loginButton.setOnClickListener { attemptLogin() }
 
         //Set the emailView text to the email saved in the preferences.
-        emailView.setText(prefs.getString(App.PREF_EMAIL, ""))
+        emailView.setText(prefs.getString(UserPreferenceKeys.EMAIL, ""))
 
         //When the user presses submit inside the passwordView, attempt a login.
         passwordView.setOnEditorActionListener { _, id, _ ->
@@ -153,7 +154,7 @@ class LoginActivity : AppCompatActivity() {
                     loginToSE(client)
                     loginToSite(client, "https://stackoverflow.com", email, password)
                     runOnUiThread {
-                        prefs.edit().putBoolean(App.PREF_HAS_CREDS, true).apply()
+                        prefs.edit().putBoolean(UserPreferenceKeys.IS_LOGGED_IN, true).apply()
                         this@LoginActivity.startActivity(Intent(this@LoginActivity, ChatActivity::class.java))
                         this@LoginActivity.finish()
                     }

--- a/app/src/main/java/com/tristanwiley/chatse/login/LoginActivity.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/login/LoginActivity.kt
@@ -2,7 +2,6 @@ package com.tristanwiley.chatse.login
 
 import android.app.ProgressDialog
 import android.content.Intent
-import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.support.design.widget.FloatingActionButton
@@ -38,26 +37,16 @@ import java.util.*
  * @property prefs: Variable used to contain the default SharedPreferences for the app. Set to App.sharedPreferences
  */
 class LoginActivity : AppCompatActivity() {
+    private val prefs = App.sharedPreferences
     lateinit var betaText: TextView
     lateinit var emailView: EditText
     lateinit var passwordView: EditText
     lateinit var loginButton: FloatingActionButton
-    lateinit var prefs: SharedPreferences
     //TODO: Replace deprecated version. Ticket is #50
     lateinit var dialog: ProgressDialog
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        //Determine if the user has logged in already, if they have, proceed to the ChatActivity and finish the LoginActivity
-        prefs = App.sharedPreferences
-        if (prefs.getBoolean(App.PREF_HAS_CREDS, false)) {
-            startActivity(Intent(this, ChatActivity::class.java))
-            finish()
-            return
-        }
-
-        //If the user has not logged in already, display the chat login layout
         setContentView(R.layout.activity_login_beautiful)
 
         activity_login_tv_version.text = String.format(Locale.getDefault(),getString(R.string.app_version), BuildConfig.VERSION_NAME)

--- a/app/src/main/java/com/tristanwiley/chatse/splash/SplashActivity.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/splash/SplashActivity.kt
@@ -3,17 +3,18 @@ package com.tristanwiley.chatse.splash
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import com.tristanwiley.chatse.App
 import com.tristanwiley.chatse.chat.ChatActivity
 import com.tristanwiley.chatse.login.LoginActivity
+import com.tristanwiley.chatse.util.SharedPreferenceManager
+import com.tristanwiley.chatse.util.UserPreferenceKeys
 
 class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val prefs = App.sharedPreferences
-        val isLoggedIn = prefs.getBoolean(App.PREF_HAS_CREDS, false)
+        val prefs = SharedPreferenceManager.sharedPreferences
+        val isLoggedIn = prefs.getBoolean(UserPreferenceKeys.IS_LOGGED_IN, false)
 
         val targetActivity = if (isLoggedIn) {
             ChatActivity::class.java

--- a/app/src/main/java/com/tristanwiley/chatse/splash/SplashActivity.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/splash/SplashActivity.kt
@@ -1,0 +1,27 @@
+package com.tristanwiley.chatse.splash
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.tristanwiley.chatse.App
+import com.tristanwiley.chatse.chat.ChatActivity
+import com.tristanwiley.chatse.login.LoginActivity
+
+class SplashActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val prefs = App.sharedPreferences
+        val isLoggedIn = prefs.getBoolean(App.PREF_HAS_CREDS, false)
+
+        val targetActivity = if (isLoggedIn) {
+            ChatActivity::class.java
+        } else {
+            LoginActivity::class.java
+        }
+
+        startActivity(Intent(this, targetActivity))
+        finish()
+    }
+}

--- a/app/src/main/java/com/tristanwiley/chatse/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/util/SharedPreferenceManager.kt
@@ -1,0 +1,44 @@
+package com.tristanwiley.chatse.util
+
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import com.tristanwiley.chatse.App
+
+object SharedPreferenceManager {
+
+    /**
+     * The default SharedPreferences for this application.
+     */
+    val sharedPreferences: SharedPreferences
+        get() = PreferenceManager.getDefaultSharedPreferences(App.instance)
+
+}
+
+class UserPreferenceKeys {
+    companion object {
+        /**
+         * The user's email.
+         */
+        const val EMAIL = "email"
+
+        /**
+         * Whether or not the user is logged in.
+         */
+        const val IS_LOGGED_IN = "is_logged_in"
+
+        /**
+         * Key for passing the room number as an intent extra.
+         */
+        const val EXTRA_ROOM_NUM = "room"
+
+        /**
+         * Key for passing the site name as an intent extra.
+         */
+        const val EXTRA_SITE = "site"
+
+        /**
+         * Key for passing the fkey as an intent extra.
+         */
+        const val EXTRA_FKEY = "fkey"
+    }
+}

--- a/app/src/main/java/com/tristanwiley/chatse/util/SharedPreferenceManager.kt
+++ b/app/src/main/java/com/tristanwiley/chatse/util/SharedPreferenceManager.kt
@@ -25,20 +25,5 @@ class UserPreferenceKeys {
          * Whether or not the user is logged in.
          */
         const val IS_LOGGED_IN = "is_logged_in"
-
-        /**
-         * Key for passing the room number as an intent extra.
-         */
-        const val EXTRA_ROOM_NUM = "room"
-
-        /**
-         * Key for passing the site name as an intent extra.
-         */
-        const val EXTRA_SITE = "site"
-
-        /**
-         * Key for passing the fkey as an intent extra.
-         */
-        const val EXTRA_FKEY = "fkey"
     }
 }


### PR DESCRIPTION
It's not the responsibility of the login activity to decide whether or not it should be shown. The login activity should just do login stuff.

Also moved the shared preference management out of the application class.